### PR TITLE
Update where docs are uploaded to:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ after_script:
   - pip install .
   - make lint
   - sudo pip install -r doc/requirements.txt --use-mirrors
+  - RELEASE=release
   - MASTER=master
-  - DEV=dev
-  - if [[ $TRAVIS_BRANCH == "$MASTER" ]] ; then export DEPLOY_HTML_DIR=docs-stable ; fi
-  - if [[ $TRAVIS_BRANCH == "$DEV" ]] ; then export DEPLOY_HTML_DIR=docs-dev ; fi
-  - if [[ $TRAVIS_BRANCH == "$MASTER" ]] || [[ $TRAVIS_BRANCH == "$DEV" ]] ; then cd doc ; make setup_gh_pages ; make generate ; make deploy ; fi
+  - if [[ $TRAVIS_BRANCH == "*$RELEASE*" ]] ; then export DEPLOY_HTML_DIR=docs ; fi
+  - if [[ $TRAVIS_BRANCH == "$MASTER" ]] ; then export DEPLOY_HTML_DIR=docs-dev ; fi
+  - if [[ $TRAVIS_BRANCH == "*$RELEASE*" ]] || [[ $TRAVIS_BRANCH == "$MASTER" ]] ; then cd doc ; make setup_gh_pages ; make generate ; make deploy ; fi
 
 # For slack notifications
 notifications:


### PR DESCRIPTION
- http://yeolab.github.io/docs : Anything that has the string "release" will be uploaded to http://yeolab.github.io/docs, since the most recent "release" is assumed to be the stable version
- http://yeolab.github.io/docs-dev : Current master branch
