### PR TITLE
Dont cache feature renamer series

### DIFF
--- a/doc/releases/v0.2.5.txt
+++ b/doc/releases/v0.2.5.txt
@@ -1,7 +1,8 @@
 v0.2.5 (......)
 ---------------------------
 
-This is a patch release, with non-breaking changes from v0.2.4.
+This is a patch release, with non-breaking changes from v0.2.4. This includes
+many changes and bugfixes. Upgrading to this version is highly recommended.
 
 Plotting functions
 ~~~~~~~~~~~~~~~~~~
@@ -34,6 +35,8 @@ Bug fixes
   :py:func:`.data_model.Study.filter_splicing_on_expression` which
   had an issue with when the index names are not `"miso_id"` or
   `"sample_id"`.
+- Don't cache :py:func:`.data_model.BaseData.feature_renamer_series`, so you
+  can change the column used to rename features
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -279,7 +279,7 @@ class BaseData(object):
         """Data from only the outlier samples"""
         return self.data.ix[self.outlier_samples]
 
-    @cached_property()
+    @property
     def feature_renamer_series(self):
         """A pandas Series of the original feature ids to the renamed ids"""
         if self.feature_data is not None:

--- a/flotilla/test/data_model/test_basedata.py
+++ b/flotilla/test/data_model/test_basedata.py
@@ -59,6 +59,27 @@ class TestBaseData:
         assert isinstance(base_data.predictor_config_manager, PredictorConfigManager)
         assert isinstance(base_data.predictor_dataset_manager, PredictorDataSetManager)
 
+    def test_feature_renamer_series_change_col(self, expression_data_no_na,
+                                               expression_feature_data,
+                                               expression_feature_rename_col,
+                                               n_genes):
+        from flotilla.data_model.base import BaseData
+        expression_feature_data = expression_feature_data.copy()
+        gene_numbers = np.arange(n_genes)
+        new_renamer = 'new_renamer'
+        expression_feature_data[new_renamer] = \
+            expression_feature_data.index.map(
+                lambda x: 'new_renamed{}'.format(
+                    np.random.choice(gene_numbers)))
+
+        base_data = BaseData(expression_data_no_na,
+                             feature_data=expression_feature_data,
+                             feature_rename_col=expression_feature_rename_col)
+        base_data.feature_rename_col = new_renamer
+        pdt.assert_series_equal(base_data.feature_renamer_series,
+                                expression_feature_data[new_renamer])
+
+
     def test__init_technical_outliers(self, expression_data_no_na,
                                       technical_outliers):
         from flotilla.data_model.base import BaseData


### PR DESCRIPTION
The feature renamer series was cached from the first name of `feature_rename_col` in `BaseData`. This removes the `@cached_property()` decorator, replacing it with just a `@property` decorator, and adds a test to show that this can happen.

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [x] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [x] ~~If it adds a new plot, is it documented in the gallery?~~
- [x] ~~Is it well formatted? Look at `make pep8` and `make lint` output~~
- [x] Is it documented in the doc/releases/? (https://github.com/YeoLab/flotilla/commit/42a2e4e32243df3dad89dde4b9084b27898555a0)
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
