### PR TITLE
Save GeneOntology data

### DIFF
--- a/doc/releases/v0.2.6.txt
+++ b/doc/releases/v0.2.6.txt
@@ -1,7 +1,7 @@
-v0.3.0 (...)
+v0.2.6 (...)
 ------------------------
 
-This is a minor release, with non-breaking changes from 0.2.5.
+This is a patch release, with non-breaking changes from 0.2.5.
 
 New features
 ~~~~~~~~~~~~

--- a/doc/releases/v0.3.0.txt
+++ b/doc/releases/v0.3.0.txt
@@ -1,0 +1,28 @@
+v0.3.0 (...)
+------------------------
+
+This is a minor release, with non-breaking changes from 0.2.5.
+
+New features
+~~~~~~~~~~~~
+
+
+Plotting functions
+~~~~~~~~~~~~~~~~~~
+
+
+API changes
+~~~~~~~~~~~
+
+
+Bug fixes
+~~~~~~~~~
+
+- Fixed :py:func:`.data_model.Study.save()` to actually save:
+    - Gene Ontology Data
+    - Minimum number of mapped reads per sample
+
+
+Miscellaneous
+~~~~~~~~~~~~~
+

--- a/flotilla/data_model/gene_ontology.py
+++ b/flotilla/data_model/gene_ontology.py
@@ -33,6 +33,9 @@ class GeneOntologyData(object):
         """
 
         self.data = data.dropna()
+
+        # Need "data_original" to be consistent with other datatypes
+        self.data_original = self.data
         sys.stdout.write('{}\tBuilding Gene Ontology '
                          'database...\n'.format(timestamp()))
         self.ontology = defaultdict(dict)

--- a/flotilla/data_model/metadata.py
+++ b/flotilla/data_model/metadata.py
@@ -26,6 +26,7 @@ class MetaData(BaseData):
         super(MetaData, self).__init__(
             data, outliers=None,
             predictor_config_manager=predictor_config_manager)
+        self.data_original = self.data
 
         self.phenotype_col = phenotype_col if phenotype_col is not None else \
             self._default_phenotype_col

--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -1635,7 +1635,7 @@ class Study(object):
             return self.splicing.big_nmf_space_transitions(
                 self.sample_id_to_phenotype, phenotype_transitions, n=n)
 
-    def save(self, name, flotilla_dir=FLOTILLA_DOWNLOAD_DIR):
+    def save(self, name, flotilla_dir=FLOTILLA_DOWNLOAD_DIR, scrambled=False):
 
         metadata = self.metadata.data
 
@@ -1693,6 +1693,11 @@ class Study(object):
             spikein = None
 
         try:
+            gene_ontology = self.gene_ontology.data
+        except AttributeError:
+            gene_ontology = None
+
+        try:
             mapping_stats = self.mapping_stats.data_original
             mapping_stats_kws = {
                 'number_mapped_col': self.mapping_stats.number_mapped_col}
@@ -1715,7 +1720,8 @@ class Study(object):
             splicing_feature_data=splicing_feature_data,
             splicing_feature_kws=splicing_feature_kws, species=self.species,
             license=self.license, title=self.title, sources=self.sources,
-            version=version, flotilla_dir=flotilla_dir)
+            version=version, flotilla_dir=flotilla_dir,
+            gene_ontology=gene_ontology)
 
     @staticmethod
     def _maybe_get_axis_name(df, axis=0, alt_name=None):

--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -1637,7 +1637,7 @@ class Study(object):
 
     def save(self, name, flotilla_dir=FLOTILLA_DOWNLOAD_DIR, scrambled=False):
 
-        metadata = self.metadata.data
+        metadata = self.metadata.data_original
 
         metadata_kws = {'pooled_col': self.metadata.pooled_col,
                         'phenotype_col': self.metadata.phenotype_col,
@@ -1700,7 +1700,8 @@ class Study(object):
         try:
             mapping_stats = self.mapping_stats.data_original
             mapping_stats_kws = {
-                'number_mapped_col': self.mapping_stats.number_mapped_col}
+                'number_mapped_col': self.mapping_stats.number_mapped_col,
+                'min_reads': self.mapping_stats.min_reads}
         except AttributeError:
             mapping_stats = None
             mapping_stats_kws = None

--- a/flotilla/datapackage.py
+++ b/flotilla/datapackage.py
@@ -174,4 +174,3 @@ def name_to_resource(datapackage, name):
         if resource['name'] == name:
             return resource
     raise ValueError('No resource named {} in this datapackage'.format(name))
-2

--- a/flotilla/datapackage.py
+++ b/flotilla/datapackage.py
@@ -93,6 +93,7 @@ def make_study_datapackage(name, metadata,
                            expression_feature_data=None,
                            splicing_feature_data=None,
                            splicing_feature_kws=None,
+                           gene_ontology=None,
                            host="https://s3-us-west-2.amazonaws.com/",
                            host_destination='flotilla-projects/'):
     """Example code for making a datapackage for a Study"""
@@ -121,7 +122,8 @@ def make_study_datapackage(name, metadata,
                  'expression_feature': (expression_feature_data,
                                         expression_feature_kws),
                  'splicing_feature': (splicing_feature_data,
-                                      splicing_feature_kws)}
+                                      splicing_feature_kws),
+                 'gene_ontology': (gene_ontology, {})}
 
     datapackage['resources'] = []
     for resource_name, (data, kws) in resources.items():
@@ -172,3 +174,4 @@ def name_to_resource(datapackage, name):
         if resource['name'] == name:
             return resource
     raise ValueError('No resource named {} in this datapackage'.format(name))
+2

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -299,8 +299,8 @@ class TestStudy(object):
 
         assert study_name == save_dir.purebasename
 
-        resource_keys_to_ignore = ('compression', 'format', 'path',
-                                   'url')
+        # resource_keys_to_ignore = ('compression', 'format', 'path',
+        #                            'url')
         keys_from_study = {'splicing': [],
                            'expression': ['thresh',
                                           'log_base',
@@ -348,8 +348,8 @@ class TestStudy(object):
         assert str(version) == test_datapackage['datapackage_version']
         assert study_name == test_datapackage['name']
 
-        datapackage_keys_to_ignore = ['name', 'datapackage_version',
-                                      'resources']
+        # datapackage_keys_to_ignore = ['name', 'datapackage_version',
+        #                               'resources']
         # datapackages = (true_datapackage, test_datapackage)
 
         # for name in resource_names:


### PR DESCRIPTION
Added functionality to perform enrichment on GeneOntology data but didn't add it to what's saved in the datapackage....oops

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [x] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [ ] ~~If it adds a new plot, is it documented in the gallery?~~~
- [x] Is it well formatted? Look at `make pep8` and `make lint` output
- [x] Is it documented in the doc/releases/?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?