### PR TITLE
Add option to scramble a study for saving and sharing unpublished results

### DIFF
--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -1635,8 +1635,35 @@ class Study(object):
             return self.splicing.big_nmf_space_transitions(
                 self.sample_id_to_phenotype, phenotype_transitions, n=n)
 
-    def save(self, name, flotilla_dir=FLOTILLA_DOWNLOAD_DIR, scrambled=False):
+    @staticmethod
+    def randomly_shuffle_df(df):
+        """Randomly shuffle columns and rows of a dataframe"""
+        df2 = df.copy()
+        features = df2.columns.values.copy()
+        np.random.shuffle(features)
+        samples = df2.index.values.copy()
+        df2.columns = features
+        df2.index = samples
+        return df2
 
+    def save(self, name, flotilla_dir=FLOTILLA_DOWNLOAD_DIR, scrambled=False):
+        """Save the current study to a "datapackage" for future loading
+
+        This allows you to "embark" on this project in the future, without
+        having to load everything yourself, but flotilla will do the heavy
+        lifting for you.
+
+        Parameters
+        ----------
+        name : str
+            Name of the package
+        flotilla_dir : str, optional
+            Where to save flotilla projects
+        scrambled : bool
+            If True, shuffle the sample and feature IDs so that sensitive
+            unpublished information isn't shared. Useful for sharing studies
+            for debugging purposes.
+        """
         metadata = self.metadata.data
 
         metadata_kws = {'pooled_col': self.metadata.pooled_col,
@@ -1651,6 +1678,9 @@ class Study(object):
 
         try:
             expression = self.expression.data_original
+            if scrambled:
+                expression = self.randomly_shuffle_df(expression)
+
             expression_kws = {
                 'log_base': self.expression.log_base,
                 'thresh': self.expression.thresh_original,
@@ -1671,6 +1701,9 @@ class Study(object):
 
         try:
             splicing = self.splicing.data_original
+            if scrambled:
+                splicing = self.randomly_shuffle_df(splicing)
+
             splicing_kws = {}
         except AttributeError:
             splicing = None
@@ -1689,6 +1722,9 @@ class Study(object):
 
         try:
             spikein = self.spikein.data_original
+            if scrambled:
+                spikein = self.randomly_shuffle_df(spikein)
+
         except AttributeError:
             spikein = None
 


### PR DESCRIPTION
Add option to `study.save` to save the current data and shuffle the gene and sample IDs so the biological signal is lost. For saving datapackages for debugging purposes, so users can submit datapackages without worrying about losing published results

- [ ] Is it mergable?
- [ ] Did it pass the tests?
- [ ] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [ ] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [ ] If it adds a new plot, is it documented in the gallery?
- [ ] Is it well formatted? Look at `make pep8` and `make lint` output
- [ ] Is it documented in the doc/releases/?
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?