### PR TITLE
Add requirement for non-plotting examples to be documented as ipython notebooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,10 @@ before the pull request is merged.
 - [ ] Do the new functions have descriptive 
   [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
   style docstrings?
-- [ ] If it adds a new plot, is it documented in the gallery?
+- [ ] If it adds a new feature, is it documented as an IPython Notebook in 
+  `examples/`, and is that notebook added to `doc/tutorial.rst`?
+- [ ] If it adds a new plot, is it documented in the gallery, as a `.py` file 
+  in `examples/`?
 - [ ] Is it well formatted? Look at `make pep8` and `make lint` output
 - [ ] Is it documented in the doc/releases/?
 - [ ] Was a spellchecker run on the source code and documentation after


### PR DESCRIPTION

Somewhat addresses the need for more examples as described here: https://github.com/YeoLab/flotilla/issues/262 but not the visual examples, rather the day-to-day grind of dealing with dataframes and creating more dataframes.

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [x] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [x] If it adds a new plot, is it documented in the gallery?
- [x] Is it well formatted? Look at `make pep8` and `make lint` output
- [x] Is it documented in the doc/releases/?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?