### PR TITLE
Update species data location

### DIFF
--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -31,7 +31,7 @@ from ..util import load_csv, load_json, load_tsv, load_gzip_pickle_df, \
 
 
 SPECIES_DATA_PACKAGE_BASE_URL = 'https://s3-us-west-2.amazonaws.com/' \
-                                'flotilla-projects'
+                                'flotilla'
 DATAPACKAGE_RESOURCE_COMMON_KWS = ('url', 'path', 'format', 'compression',
                                    'name')
 
@@ -209,8 +209,6 @@ class Study(object):
         # self.predictor_config_manager = None
 
         self.species = species
-        if gene_ontology_data is not None:
-            self.gene_ontology = GeneOntologyData(gene_ontology_data)
 
         self.license = license
         self.title = title
@@ -271,33 +269,27 @@ class Study(object):
             sys.stdout.write('{}\tLoading species metadata from '
                              '~/flotilla_packages\n'.format(timestamp()))
             species_kws = self.load_species_data(self.species, self.readers)
-            expression_feature_data = species_kws.pop(
-                'expression_feature_data',
-                None)
-            expression_feature_rename_col = species_kws.pop(
-                'expression_feature_rename_col', None)
-            splicing_feature_data = species_kws.pop('splicing_feature_data',
-                                                    None)
-            splicing_feature_rename_col = species_kws.pop(
-                'splicing_feature_rename_col', None)
-
             if expression_feature_data is None:
                 expression_feature_data = species_kws.pop(
-                    'expression_feature_data',
-                    None)
-
-            if expression_feature_rename_col is None:
+                    'expression_feature_data', None)            
                 expression_feature_rename_col = species_kws.pop(
                     'expression_feature_rename_col', None)
-
+                expression_feature_ignore_subset_cols = species_kws.pop(
+                    'expression_feature_ignore_subset_cols', None)
+                
             if splicing_feature_data is None:
-                splicing_feature_data = species_kws.pop(
-                    'splicing_feature_data',
-                    None)
-
-            if splicing_feature_rename_col is None:
+                splicing_feature_data = species_kws.pop('splicing_feature_data',
+                                                        None)
                 splicing_feature_rename_col = species_kws.pop(
                     'splicing_feature_rename_col', None)
+                splicing_feature_expression_id_col = species_kws.pop(
+                    'splicing_feature_expression_id_col', None)
+                splicing_feature_ignore_subset_cols = species_kws.pop(
+                    'splicing_feature_ignore_subset_cols', None)
+
+            if gene_ontology_data is None:
+                gene_ontology_data = species_kws.pop('gene_ontology_data',
+                                                     None)
 
         if expression_data is not None:
             sys.stdout.write(
@@ -341,6 +333,9 @@ class Study(object):
         else:
             self.spikein = None
         self.supplemental = SupplementalData(supplemental_data)
+        if gene_ontology_data is not None:
+            self.gene_ontology = GeneOntologyData(gene_ontology_data)
+
         sys.stdout.write("{}\tSuccessfully initialized a Study "
                          "object!\n".format(timestamp()))
 
@@ -612,7 +607,7 @@ class Study(object):
                     resource['compression']
                 name = resource['name']
                 dfs[name] = reader(filename,
-                                   compression=compression)
+                                   compression=compression, index_col=0)
                 other_keys = set(resource.keys()).difference(
                     DATAPACKAGE_RESOURCE_COMMON_KWS)
                 name_no_data = name.rstrip('_data')

--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -271,15 +271,15 @@ class Study(object):
             species_kws = self.load_species_data(self.species, self.readers)
             if expression_feature_data is None:
                 expression_feature_data = species_kws.pop(
-                    'expression_feature_data', None)            
+                    'expression_feature_data', None)
                 expression_feature_rename_col = species_kws.pop(
                     'expression_feature_rename_col', None)
                 expression_feature_ignore_subset_cols = species_kws.pop(
                     'expression_feature_ignore_subset_cols', None)
-                
+
             if splicing_feature_data is None:
-                splicing_feature_data = species_kws.pop('splicing_feature_data',
-                                                        None)
+                splicing_feature_data = species_kws.pop(
+                    'splicing_feature_data', None)
                 splicing_feature_rename_col = species_kws.pop(
                     'splicing_feature_rename_col', None)
                 splicing_feature_expression_id_col = species_kws.pop(

--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -584,7 +584,33 @@ class Study(object):
     @staticmethod
     def load_species_data(
             species, readers,
-            species_datapackage_base_url=SPECIES_DATA_PACKAGE_BASE_URL):
+            species_datapackage_base_url=SPECIES_DATA_PACKAGE_BASE_URL,
+            nrows=None):
+        """
+
+        Parameters
+        ----------
+        species : str
+            Name of the species with genoem build, e.g. "hg19" or "mm10"
+        readers : dict
+            Mapping of file types to pandas readers
+        species_datapackage_base_url : str, optional
+            Url where the species name and datapackage could be appended, i.e.:
+            species_datapackage_base_url/species/datapackage.json
+            is a valid location
+        nrows : int, optional
+            Number of rows to read in. Useful for reading chunks of large files
+
+        Returns
+        -------
+        data : dict
+            A string to dataframe or value mapping of all entries in the
+            species datapackage.
+
+        Raises
+        ------
+
+        """
         dfs = {}
 
         try:
@@ -607,7 +633,8 @@ class Study(object):
                     resource['compression']
                 name = resource['name']
                 dfs[name] = reader(filename,
-                                   compression=compression, index_col=0)
+                                   compression=compression, index_col=0,
+                                   nrows=nrows)
                 other_keys = set(resource.keys()).difference(
                     DATAPACKAGE_RESOURCE_COMMON_KWS)
                 name_no_data = name.rstrip('_data')

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -231,7 +231,9 @@ class TestStudy(object):
 
     def test_load_species(self, species):
         from flotilla import Study
-        species_data = Study.load_species_data(species, Study.readers)
+
+        species_data = Study.load_species_data(species, Study.readers,
+                                               nrows=100)
 
         assert 'expression_feature_data' in species_data
         assert 'splicing_feature_data' in species_data

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -27,9 +27,11 @@ def color_samples_by(request, metadata_phenotype_col):
     else:
         return request.param
 
+
 @pytest.fixture(params=['hg19', 'mm10'])
 def species(request):
     return request.param
+
 
 class TestStudy(object):
     # @pytest.fixture

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -27,6 +27,9 @@ def color_samples_by(request, metadata_phenotype_col):
     else:
         return request.param
 
+@pytest.fixture(params=['hg19', 'mm10'])
+def species(request):
+    return request.param
 
 class TestStudy(object):
     # @pytest.fixture
@@ -223,6 +226,14 @@ class TestStudy(object):
                       **kwargs)
         pdt.assert_array_equal(study.splicing.data_original,
                                splicing_data)
+
+    def test_load_species(self, species):
+        from flotilla import Study
+        species_data = Study.load_species_data(species, Study.readers)
+
+        assert 'expression_feature_data' in species_data
+        assert 'splicing_feature_data' in species_data
+        assert 'gene_ontology_data' in species_data
 
     def test_feature_subset_to_feature_ids(self, study, data_type,
                                            feature_subset):


### PR DESCRIPTION
Update the species data location to https://s3-us-west-2.amazonaws.com/flotilla (which I have access to edit), and fix up the reading of these files to set the first column as the index, and updated the hg19 data to include cell cycle, and more useful things.

- [ ] Is it mergable?
- [ ] Did it pass the tests?
- [ ] If it introduces new functionality in is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [ ] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [ ] If it adds a new feature, is it documented as an IPython Notebook in 
  `examples/`, and is that notebook added to `doc/tutorial.rst`?
- [ ] If it adds a new plot, is it documented in the gallery, as a `.py` file 
  in `examples/`?
- [ ] Is it well formatted? Look at `make pep8` and `make lint` output
- [ ] Is it documented in the doc/releases/?
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?