### PR TITLE
Plotting changes

### DIFF
--- a/doc/releases/v0.2.6.txt
+++ b/doc/releases/v0.2.6.txt
@@ -36,4 +36,13 @@ Miscellaneous
 - Improved accuracy (fewer false positives) in splicing modality estimation
 - Added requirement for new non-plotting features to at least be documented as
   IPython notebooks, so the knowledge is shared.
-- Change PCA plot to place legend in "best" place
+- Changed PCA plot to place legend in "best" place
+- Changed default plotting marker from a circle to a randomly chosen symbol
+  from a list
+- Violinplots are now variable width and expand with the number of samples
+    - This was changed in :py:meth:`.data_model.Study.plot_gene`,
+    :py:meth:`.data_model.Study.plot_event` and
+    :py:meth:`.data_model.Study.plot_pca` when ``plot_violins=True``
+- Add info about data type when reporting that a feature was not found
+
+

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -1060,6 +1060,7 @@ class BaseData(object):
         feature_ids = self.maybe_renamed_to_feature_id(feature_id)
         if phenotype_groupby is None:
             phenotype_groupby = pd.Series('all', index=self.data.index)
+        phenotype_groupby = pd.Series(phenotype_groupby)
 
         if not isinstance(feature_ids, pd.Index):
             feature_ids = [feature_id]

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -1063,13 +1063,20 @@ class BaseData(object):
         if not isinstance(feature_ids, pd.Index):
             feature_ids = [feature_id]
 
+        grouped = phenotype_groupby.groupby(phenotype_groupby)
+        single_violin_width = 0.5
+        ax_width = max(4, single_violin_width*grouped.size().shape[0])
+
         if fig is None and axesgrid is None:
             nrows = len(feature_ids)
             ncols = 2 if nmf_space else 1
-            figsize = 4 * ncols, 4 * nrows
+            figsize = ax_width * ncols, 4 * nrows
+            gridspec_kws = {}
+            if nmf_space:
+                gridspec_kws['width_ratios'] = (ax_width, 4)
 
             fig, axesgrid = plt.subplots(nrows=nrows, ncols=ncols,
-                                         figsize=figsize)
+                                         figsize=figsize, **gridspec_kws)
             if nrows == 1:
                 axesgrid = [axesgrid]
 

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -319,9 +319,10 @@ class BaseData(object):
         elif feature_id in self.data.columns:
             return feature_id
         else:
-            raise ValueError('{} is not a valid feature identifier (it may '
-                             'not have been measured in this dataset!)'
-                             .format(feature_id))
+            raise ValueError('{} is not a valid feature identifier for "{}" '
+                             'data (it may not have been measured in this '
+                             'dataset!)'
+                             .format(self.data_type, feature_id))
 
     @property
     def _var_cut(self):
@@ -1076,7 +1077,8 @@ class BaseData(object):
                 gridspec_kws['width_ratios'] = (ax_width, 4)
 
             fig, axesgrid = plt.subplots(nrows=nrows, ncols=ncols,
-                                         figsize=figsize, **gridspec_kws)
+                                         figsize=figsize,
+                                         gridspec_kws=gridspec_kws)
             if nrows == 1:
                 axesgrid = [axesgrid]
 

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -1072,13 +1072,13 @@ class BaseData(object):
             nrows = len(feature_ids)
             ncols = 2 if nmf_space else 1
             figsize = ax_width * ncols, 4 * nrows
-            gridspec_kws = {}
+            gridspec_kw = {}
             if nmf_space:
-                gridspec_kws['width_ratios'] = (ax_width, 4)
+                gridspec_kw['width_ratios'] = (ax_width, 4)
 
             fig, axesgrid = plt.subplots(nrows=nrows, ncols=ncols,
                                          figsize=figsize,
-                                         gridspec_kws=gridspec_kws)
+                                         gridspec_kw=gridspec_kw)
             if nrows == 1:
                 axesgrid = [axesgrid]
 

--- a/flotilla/data_model/metadata.py
+++ b/flotilla/data_model/metadata.py
@@ -155,7 +155,11 @@ class MetaData(BaseData):
 
     @property
     def phenotype_to_marker(self):
-        _default_phenotype_to_marker = defaultdict(lambda: 'o')
+        markers = cycle(['o', '^', 's', 'v', '*', 'D', ])
+
+        def marker_factory():
+            return markers.next()
+        _default_phenotype_to_marker = defaultdict(marker_factory)
         all_phenotypes = self._phenotype_to_marker.keys()
         all_phenotypes.extend(self.phenotype_order)
         return dict((k, self._phenotype_to_marker[k])

--- a/flotilla/data_model/metadata.py
+++ b/flotilla/data_model/metadata.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import sys
 import warnings
+from itertools import cycle
 
 import matplotlib as mpl
 import pandas as pd
@@ -65,20 +66,23 @@ class MetaData(BaseData):
                 self._phenotype_to_color[phenotype] = color
 
         self.phenotype_to_marker = phenotype_to_marker
+
+        markers = cycle(['o', '^', 's', 'v', '*', 'D', ])
         if self.phenotype_to_marker is not None:
             for phenotype in self.unique_phenotypes:
                 try:
                     marker = self.phenotype_to_marker[phenotype]
                 except KeyError:
+                    marker = markers.next()
                     sys.stderr.write(
                         '{} does not have marker style, '
-                        'falling back on "o" (circle)'.format(phenotype))
-                    marker = 'o'
+                        'falling back on "{}"'.format(phenotype, marker))
                 if marker not in mpl.markers.MarkerStyle.filled_markers:
+                    correct_marker = markers.next()
                     sys.stderr.write(
                         '{} is not a valid matplotlib marker style, '
-                        'falling back on "o" (circle)'.format(marker))
-                    marker = 'o'
+                        'falling back on "{}"'.format(marker, correct_marker))
+                    marker = correct_marker
                 self.phenotype_to_marker[phenotype] = marker
 
     @property
@@ -165,10 +169,14 @@ class MetaData(BaseData):
             self._phenotype_to_marker = value
         else:
             sys.stderr.write('No phenotype to marker (matplotlib plotting '
-                             'symbol) was provided, so each phenotype will be '
-                             'plotted as a circle in visualizations.\n')
-            self._phenotype_to_marker = dict.fromkeys(self.unique_phenotypes,
-                                                      'o')
+                             'symbol) was provided, falling back on reasonable'
+                             ' defaults.\n')
+            markers = cycle(['o', '^', 's', 'v', '*', 'D', ])
+
+            def marker_factory():
+                return markers.next()
+
+            self._phenotype_to_marker = defaultdict(marker_factory)
 
     @property
     def phenotype_color_order(self):

--- a/flotilla/test/data_model/test_metadata.py
+++ b/flotilla/test/data_model/test_metadata.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from itertools import cycle
 
 import matplotlib as mpl
 import numpy as np
@@ -66,8 +67,14 @@ class TestMetaData(object):
                 true_phenotype_to_color[phenotype] = color
 
         if phenotype_to_marker is None:
-            true_phenotype_to_marker = dict.fromkeys(
-                test_metadata.unique_phenotypes, 'o')
+            markers = cycle(['o', '^', 's', 'v', '*', 'D', ])
+
+            def marker_factory():
+                return markers.next()
+            true_phenotype_to_marker = defaultdict(marker_factory)
+            for x in true_phenotype_order:
+                true_phenotype_to_marker[x]
+
         else:
             true_phenotype_to_marker = phenotype_to_marker
 

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -355,8 +355,13 @@ class TestStudy(object):
         true_figsize = ax_width * ncols, 4 * nrows
         npt.assert_array_equal(true_figsize, test_figsize)
 
-    def test_plot_pca(self, study, data_type):
-        study.plot_pca(feature_subset='all', data_type=data_type)
+    @pytest.fixture(params=[True, False])
+    def plot_violins(self, request):
+        return request.param
+
+    def test_plot_pca(self, study, data_type, plot_violins):
+        study.plot_pca(feature_subset='all', data_type=data_type,
+                       plot_violins=plot_violins)
         plt.close('all')
 
     # Too few features to test graph or classifier

--- a/flotilla/test/data_model/test_study.py
+++ b/flotilla/test/data_model/test_study.py
@@ -296,6 +296,65 @@ class TestStudy(object):
                 columns=columns, index=index, values='psi')
         pdt.assert_frame_equal(true_filtered_splicing, test_filtered_splicing)
 
+    def test_plot_gene(self, study):
+        feature_id = study.expression.data.columns[0]
+        study.plot_gene(feature_id)
+
+        fig = plt.gcf()
+        test_figsize = fig.get_size_inches()
+
+        feature_ids = [feature_id]
+        groupby = study.sample_id_to_phenotype
+        grouped = groupby.groupby(groupby)
+        single_violin_width = 0.5
+        ax_width = max(4, single_violin_width*grouped.size().shape[0])
+        nrows = len(feature_ids)
+        ncols = 1
+        true_figsize = ax_width * ncols, 4 * nrows
+        npt.assert_array_equal(true_figsize, test_figsize)
+
+    @pytest.fixture(params=[True, False])
+    def nmf_space(self, request):
+        return request.param
+
+    def test_plot_event(self, study, nmf_space):
+        feature_id = study.splicing.data.columns[0]
+        study.plot_event(feature_id, nmf_space=nmf_space)
+
+        fig = plt.gcf()
+        test_figsize = fig.get_size_inches()
+
+        feature_ids = [feature_id]
+        groupby = study.sample_id_to_phenotype
+        grouped = groupby.groupby(groupby)
+        single_violin_width = 0.5
+        ax_width = max(4, single_violin_width*grouped.size().shape[0])
+        nrows = len(feature_ids)
+        ncols = 2 if nmf_space else 1
+        true_figsize = ax_width * ncols, 4 * nrows
+        npt.assert_array_equal(true_figsize, test_figsize)
+
+    def test_plot_event_multiple_events_per_id(self, study, nmf_space):
+        grouped = study.splicing.feature_data.groupby(
+            study.splicing.feature_rename_col)
+        ids_with_multiple_genes = grouped.filter(lambda x: len(x) > 1)
+        feature_id = ids_with_multiple_genes[
+            study.splicing.feature_rename_col].values[0]
+        study.plot_event(feature_id, nmf_space=nmf_space)
+
+        fig = plt.gcf()
+        test_figsize = fig.get_size_inches()
+
+        feature_ids = study.splicing.maybe_renamed_to_feature_id(feature_id)
+        groupby = study.sample_id_to_phenotype
+        grouped = groupby.groupby(groupby)
+        single_violin_width = 0.5
+        ax_width = max(4, single_violin_width*grouped.size().shape[0])
+        nrows = len(feature_ids)
+        ncols = 2 if nmf_space else 1
+        true_figsize = ax_width * ncols, 4 * nrows
+        npt.assert_array_equal(true_figsize, test_figsize)
+
     def test_plot_pca(self, study, data_type):
         study.plot_pca(feature_subset='all', data_type=data_type)
         plt.close('all')

--- a/flotilla/visualize/decomposition.py
+++ b/flotilla/visualize/decomposition.py
@@ -455,14 +455,17 @@ class DecompositionViz(object):
         Must be called after plot_samples because it depends on the existence
         of the "self.magnitudes" attribute.
         """
-        ncols = 4
+        single_violin_width = 0.5
+        ax_width = max(4, single_violin_width*self.grouped.size().shape[0])
+        ncols = int(np.ceil(16/ax_width))
         nrows = 1
         vector_labels = list(set(self.magnitudes[:self.n_vectors].index.union(
             pd.Index(self.top_features))))
         while ncols * nrows < len(vector_labels):
             nrows += 1
         self.fig_violins, axes = plt.subplots(nrows=nrows, ncols=ncols,
-                                              figsize=(4 * ncols, 4 * nrows))
+                                              figsize=(ax_width * ncols,
+                                                       4 * nrows))
 
         if self.feature_renamer is not None:
             renamed_vectors = map(self.feature_renamer, vector_labels)


### PR DESCRIPTION
* Variable width violin plots for when you have lots of phenotypes
* Change default phenotype to marker from circle to a variety of shapes because it can be hard to tell between label colors

before and after of variable width violin plots
before:
![image](https://cloud.githubusercontent.com/assets/806256/7045145/09a1d984-ddb0-11e4-9a8d-69929d11402e.png)

After:
![image](https://cloud.githubusercontent.com/assets/806256/7045150/114852da-ddb0-11e4-9e20-fe87498af5e1.png)


Before and afters of changing default phenotype to marker:
Before:
![image](https://cloud.githubusercontent.com/assets/806256/7045130/dede155a-ddaf-11e4-9587-c9287285e718.png)

After:
![image](https://cloud.githubusercontent.com/assets/806256/7045137/f4c62a56-ddaf-11e4-801c-4112e8136bed.png)

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [x] ~~Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?~~
- [x] ~~If it adds a new feature, is it documented as an IPython Notebook in 
  `examples/`, and is that notebook added to `doc/tutorial.rst`?~~
- [x] ~~If it adds a new plot, is it documented in the gallery, as a `.py` file 
  in `examples/`?~~
- [x] Is it well formatted? Look at `make pep8` and `make lint` output
- [x] Is it documented in the doc/releases/?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?