### PR TITLE
Metadata ignore subset columns

### DIFF
--- a/flotilla/data_model/metadata.py
+++ b/flotilla/data_model/metadata.py
@@ -24,7 +24,8 @@ class MetaData(BaseData):
                  pooled_col=POOLED_COL,
                  outlier_col=OUTLIER_COL,
                  predictor_config_manager=None,
-                 minimum_sample_subset=MINIMUM_SAMPLE_SUBSET):
+                 minimum_sample_subset=MINIMUM_SAMPLE_SUBSET,
+                 ignore_subset_columns=None):
         super(MetaData, self).__init__(
             data, outliers=None,
             predictor_config_manager=predictor_config_manager)
@@ -37,6 +38,7 @@ class MetaData(BaseData):
         self.pooled_col = pooled_col
         self.minimum_sample_subset = minimum_sample_subset
         self.outlier_col = outlier_col
+        self.ignore_subset_columns = ignore_subset_columns
 
         phenotypes_not_in_order = set(self.unique_phenotypes).difference(
             set(self.phenotype_order))
@@ -196,7 +198,8 @@ class MetaData(BaseData):
     @property
     def sample_subsets(self):
         return subsets_from_metadata(self.data, self.minimum_sample_subset,
-                                     'samples')
+                                     'samples',
+                                     ignore=self.ignore_subset_columns)
 
     @property
     def phenotype_series(self):

--- a/flotilla/data_model/study.py
+++ b/flotilla/data_model/study.py
@@ -100,6 +100,7 @@ class Study(object):
                  metadata_phenotype_to_color=None,
                  metadata_phenotype_to_marker=None,
                  metadata_outlier_col=OUTLIER_COL,
+                 metadata_ignore_subset_columns=None,
                  license=None, title=None, sources=None,
                  default_sample_subset="all_samples",
                  default_feature_subset="variant",
@@ -225,7 +226,8 @@ class Study(object):
             outlier_col=metadata_outlier_col,
             phenotype_col=metadata_phenotype_col,
             predictor_config_manager=self.predictor_config_manager,
-            minimum_sample_subset=metadata_minimum_samples)
+            minimum_sample_subset=metadata_minimum_samples,
+            ignore_subset_columns=metadata_ignore_subset_columns)
 
         self.default_feature_subset = default_feature_subset
         self.default_sample_subset = default_sample_subset

--- a/flotilla/test/data_model/test_metadata.py
+++ b/flotilla/test/data_model/test_metadata.py
@@ -11,19 +11,22 @@ import pandas.util.testing as pdt
 
 class TestMetaData(object):
     @pytest.fixture
-    def metadata(self):
-        n = 20
+    def phenotype_col(self):
+        return 'phenotype'
+
+    @pytest.fixture
+    def n(self):
+        return 20
+
+    @pytest.fixture
+    def metadata(self, n, phenotype_col):
         index = ['sample_{}'.format(i + 1) for i in range(n)]
         metadata = pd.DataFrame(index=index)
-        phenotype_col = 'phenotype'
         metadata[phenotype_col] = np.random.choice(list('ABC'), size=20)
         metadata['subset1'] = np.random.choice([True, False], size=20)
         return metadata
 
-    @pytest.fixture
-    def kws(self):
-        kws = {'minimum_sample_subset': 2,
-               'phenotype_col': phenotype_col}
+
 
     @pytest.fixture(params=[None, list('CAB')])
     def phenotype_order(self, request):
@@ -38,17 +41,24 @@ class TestMetaData(object):
     def phenotype_to_marker(self, request):
         return request.param
 
-    def test_init(self, metadata, phenotype_order, phenotype_to_color,
-                  phenotype_to_marker):
+    @pytest.fixture
+    def kws(self, phenotype_col, phenotype_order, phenotype_to_color,
+            phenotype_to_marker):
+        return {'minimum_sample_subset': 2,
+               'phenotype_col': phenotype_col,
+               'phenotype_to_marker': phenotype_to_marker,
+               'phenotype_order': phenotype_order,
+               'phenotype_to_color': phenotype_to_color}
+
+
+    def test_init(self, metadata, phenotype_col,
+                  phenotype_order, phenotype_to_color,
+                  phenotype_to_marker, kws):
         from flotilla.data_model.metadata import MetaData
         from flotilla.data_model.base import subsets_from_metadata
         from flotilla.visualize.color import str_to_color
 
-        test_metadata = MetaData(self.metadata,
-                                 phenotype_order=phenotype_order,
-                                 phenotype_to_color=phenotype_to_color,
-                                 phenotype_to_marker=phenotype_to_marker,
-                                 **self.kws)
+        test_metadata = MetaData(metadata, **kws)
 
         if phenotype_order is None:
             true_phenotype_order = list(sorted(
@@ -85,7 +95,7 @@ class TestMetaData(object):
 
         true_phenotype_transitions = zip(true_phenotype_order[:-1],
                                          true_phenotype_order[1:])
-        true_unique_phenotypes = self.metadata[self.phenotype_col].unique()
+        true_unique_phenotypes = metadata[phenotype_col].unique()
         true_n_phenotypes = len(true_unique_phenotypes)
 
         true_colors = map(mpl.colors.rgb2hex,
@@ -94,17 +104,17 @@ class TestMetaData(object):
         colors = iter(true_colors)
         true_default_phenotype_to_color = defaultdict(lambda: colors.next())
 
-        true_sample_id_to_phenotype = self.metadata[self.phenotype_col]
+        true_sample_id_to_phenotype = metadata[phenotype_col]
         true_phenotype_color_order = [true_phenotype_to_color[p]
                                       for p in true_phenotype_order]
         true_sample_id_to_color = \
             dict((i, true_phenotype_to_color[true_sample_id_to_phenotype[i]])
-                 for i in self.metadata.index)
+                 for i in metadata.index)
 
         true_sample_subsets = subsets_from_metadata(
-            self.metadata, self.kws['minimum_sample_subset'], 'samples')
+            metadata, kws['minimum_sample_subset'], 'samples')
 
-        pdt.assert_frame_equal(test_metadata.data, self.metadata)
+        pdt.assert_frame_equal(test_metadata.data, metadata)
         pdt.assert_series_equal(test_metadata.sample_id_to_phenotype,
                                 true_sample_id_to_phenotype)
         pdt.assert_array_equal(test_metadata.unique_phenotypes,
@@ -132,6 +142,7 @@ class TestMetaData(object):
                               true_sample_subsets)
 
     def test_ignore_subset_columns(self, metadata, phenotype_order,
+                                   phenotype_col,
                                    phenotype_to_color, phenotype_to_marker,
                                    kws):
         from flotilla.data_model.metadata import MetaData
@@ -140,26 +151,19 @@ class TestMetaData(object):
         metadata['no_subset'] = np.arange(metadata.shape[0])
         ignore_subset_columns = 'no_subset'
 
-        test_metadata = MetaData(metadata,
-                                 phenotype_order=phenotype_order,
-                                 phenotype_to_color=phenotype_to_color,
-                                 phenotype_to_marker=phenotype_to_marker,
-                                 **kws)
+        test_metadata = MetaData(metadata, **kws)
         assert 'no_subset' not in test_metadata.sample_subsets
 
 
-    def test_change_phenotype_col(self, metadata,
+    def test_change_phenotype_col(self, metadata, n, phenotype_col,
                                   phenotype_order, phenotype_to_color,
-                                  phenotype_to_marker):
+                                  phenotype_to_marker, kws):
         from flotilla.data_model.metadata import MetaData
 
         metadata = metadata.copy()
-        metadata['phenotype2'] = np.random.choice(list('QXYZ'), size=self.n)
+        metadata['phenotype2'] = np.random.choice(list('QXYZ'), size=n)
 
-        test_metadata = MetaData(metadata, phenotype_order,
-                                 phenotype_to_color,
-                                 phenotype_to_marker,
-                                 phenotype_col='phenotype')
+        test_metadata = MetaData(metadata, **kws)
         test_metadata.phenotype_col = 'phenotype2'
 
         pdt.assert_array_equal(test_metadata.unique_phenotypes,


### PR DESCRIPTION
Add option to ignore columns in the metadata for creating sample subsets.

- [ ] Is it mergable?
- [ ] Did it pass the tests?
- [ ] If it introduces new functionality in is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `py.test --cov flotilla/compute/splicing.py --cov-report term-missing flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [ ] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [ ] If it adds a new feature, is it documented as an IPython Notebook in 
  `examples/`, and is that notebook added to `doc/tutorial.rst`?
- [ ] If it adds a new plot, is it documented in the gallery, as a `.py` file 
  in `examples/`?
- [ ] Is it well formatted? Look at `make pep8` and `make lint` output
- [ ] Is it documented in the doc/releases/?
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?