### PR TITLE
Update violinplots to work with seaborn 0.6

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -15,7 +15,7 @@ ipython >= 2.0.0
 patsy >= 0.2.1
 pandas >= 0.13.1
 statsmodels >= 0.5.0
-seaborn >= 0.5
+seaborn >= 0.6
 networkx
 tornado >= 3.2.1
 pyzmq

--- a/flotilla/data_model/base.py
+++ b/flotilla/data_model/base.py
@@ -995,7 +995,7 @@ class BaseData(object):
     def _violinplot(self, feature_id, sample_ids=None,
                     phenotype_groupby=None,
                     phenotype_order=None, ax=None, color=None,
-                    label_pooled=False):
+                    label_pooled=False, **kwargs):
         """For compatiblity across data types, can specify _violinplot
         """
         sample_ids = self.data.index if sample_ids is None else sample_ids
@@ -1021,8 +1021,8 @@ class BaseData(object):
 
         violinplot(singles, groupby=phenotype_groupby, color_ordered=color,
                    pooled_data=pooled, order=phenotype_order,
-                   title=title, data_type=self.data_type, ax=ax,
-                   label_pooled=label_pooled, outliers=outliers)
+                   title=title, ax=ax,
+                   outliers=outliers, **kwargs)
 
     @staticmethod
     def _thresh_int(df, n):
@@ -1053,7 +1053,8 @@ class BaseData(object):
                      phenotype_to_color=None,
                      phenotype_to_marker=None, nmf_xlabel=None,
                      nmf_ylabel=None,
-                     nmf_space=False, fig=None, axesgrid=None, n=20):
+                     nmf_space=False, fig=None, axesgrid=None, n=20,
+                     violinplot_kws=None):
         """
         Plot the violinplot of a feature. Have the option to show NMF movement
         """
@@ -1061,6 +1062,7 @@ class BaseData(object):
         if phenotype_groupby is None:
             phenotype_groupby = pd.Series('all', index=self.data.index)
         phenotype_groupby = pd.Series(phenotype_groupby)
+        violinplot_kws = {} if violinplot_kws is None else violinplot_kws
 
         if not isinstance(feature_ids, pd.Index):
             feature_ids = [feature_id]
@@ -1092,7 +1094,7 @@ class BaseData(object):
             self._violinplot(feature_id, sample_ids=sample_ids,
                              phenotype_groupby=phenotype_groupby,
                              phenotype_order=phenotype_order, ax=axes[0],
-                             color=color)
+                             color=color, **violinplot_kws)
 
             if nmf_space:
                 try:

--- a/flotilla/data_model/splicing.py
+++ b/flotilla/data_model/splicing.py
@@ -361,14 +361,19 @@ class SplicingData(BaseData):
                      phenotype_to_color=None,
                      phenotype_to_marker=None, nmf_xlabel=None,
                      nmf_ylabel=None,
-                     nmf_space=False, fig=None, axesgrid=None, n=20):
+                     nmf_space=False, fig=None, axesgrid=None, n=20,
+                     violinplot_kws=None):
         if nmf_space:
             nmf_xlabel = self._nmf_space_xlabel(phenotype_groupby)
             nmf_ylabel = self._nmf_space_ylabel(phenotype_groupby)
         else:
             nmf_ylabel = None
             nmf_xlabel = None
-
+        violinplot_kws = {} if violinplot_kws is None else violinplot_kws
+        violinplot_kws.setdefault('bw', 0.2)
+        violinplot_kws.setdefault('ylim', (0, 1))
+        violinplot_kws.setdefault('yticks', (0, 0.5, 1))
+        violinplot_kws.setdefault('ylabel', '$\Psi$')
         super(SplicingData, self).plot_feature(feature_id, sample_ids,
                                                phenotype_groupby,
                                                phenotype_order, color,
@@ -376,7 +381,8 @@ class SplicingData(BaseData):
                                                phenotype_to_marker, nmf_xlabel,
                                                nmf_ylabel, nmf_space=nmf_space,
                                                fig=fig, axesgrid=axesgrid,
-                                               n=n)
+                                               n=n,
+                                               violinplot_kws=violinplot_kws)
 
     @memoize
     def pooled_inconsistent(self, data, feature_ids=None,

--- a/flotilla/visualize/generic.py
+++ b/flotilla/visualize/generic.py
@@ -54,7 +54,7 @@ def violinplot(singles, groupby, color_ordered=None, ax=None,
     if not singles.dropna().empty:
         sns.stripplot(x='phenotype', y=ylabel, data=tidy_singles,
                   jitter=True, order=order, ax=ax, palette=color_ordered)
-    if pooled is not None not pooled.dropna().empty:
+    if pooled is not None and not pooled.dropna().empty:
         sns.stripplot(x='phenotype', y=ylabel, data=tidy_pooled,
                       jitter=True, order=order, ax=ax, color='#262626')
     sizes = tidy_singles.groupby('phenotype').size()

--- a/flotilla/visualize/generic.py
+++ b/flotilla/visualize/generic.py
@@ -5,23 +5,41 @@ import seaborn as sns
 
 def violinplot(singles, groupby, color_ordered=None, ax=None,
                pooled=None, ylabel='', bw=None,
-               order=None, title=None,
-               outliers=None, data_type=None):
+               order=None, title=None, ylim=None, yticks=None,
+               outliers=None, **kwargs):
     """
     Parameters
     ----------
-    data : pandas.Series
-        The main data to plot
-    groupby : dict-like
-        How to group the samples (e.g. by phenotype)
-    color_ordered : list
+    singles : pandas.Series
+        Gene expression or splicing values from single cells
+    groupby : pandas.Series
+        A sample to group mapping for each sample id
+    color_ordered : list, optional
+        List of colors in the correct phenotype order
+    ax : matplotlib.Axes object, optional
+        Axes to plot on
+    pooled : pandas.Series
+        Gene expression or splicing values from pooled samples
+    ylabel : str
+        How to label the y-axis
+    bw : float
+        Width of the bandwidths for estimating the kernel density
+    order : list
+        Which order to plot the groups in
+    title : str
+        Title of the plot
+    ylim : tuple
+        Length 2 tuple specifying the minimum and maxmimum values to
+        be plotted on the y-axis
+    yticks : list
+        Where to position yticks
+    outliers : pandas.Series
+        Gene expression or splicing values from outlier cells
 
     Returns
     -------
-
-
-    Raises
-    ------
+    ax : matplotlib.Axes object
+        Axes with violinplot plotted
     """
     if ax is None:
         ax = plt.gca()
@@ -42,24 +60,28 @@ def violinplot(singles, groupby, color_ordered=None, ax=None,
 
     if outliers is not None and not outliers.dropna().empty:
         sns.violinplot(x='phenotype', y=ylabel, data=tidy_outliers,
-                   bw=0.2, order=order, inner=None, cut=0,
-                   linewidth=1, scale='width', color='lightgrey', ax=ax)
+                       bw=bw, order=order, inner=None, cut=0,
+                       linewidth=1, scale='width', color='lightgrey', ax=ax,
+                       **kwargs)
     if not singles.dropna().empty:
         sns.violinplot(x='phenotype', y=ylabel, data=tidy_singles,
-                   bw=0.2, order=order, inner=None, cut=0,
-                   linewidth=1, scale='width', palette=color_ordered, ax=ax)
+                       bw=bw, order=order, inner=None, cut=0,
+                       linewidth=1, scale='width', palette=color_ordered, ax=ax,
+                       **kwargs)
     if outliers is not None and not outliers.dropna().empty:
         sns.stripplot(x='phenotype', y=ylabel, data=tidy_outliers,
-                  jitter=True, order=order, ax=ax, color='grey')
+                      jitter=True, order=order, ax=ax, color='grey')
     if not singles.dropna().empty:
         sns.stripplot(x='phenotype', y=ylabel, data=tidy_singles,
-                  jitter=True, order=order, ax=ax, palette=color_ordered)
+                      jitter=True, order=order, ax=ax, palette=color_ordered)
     if pooled is not None and not pooled.dropna().empty:
         sns.stripplot(x='phenotype', y=ylabel, data=tidy_pooled,
                       jitter=True, order=order, ax=ax, color='#262626')
     sizes = tidy_singles.groupby('phenotype').size()
 
-    ax.set_xticklabels(['{0}\nn={1}'.format(group, sizes[group]) if group in sizes else group for group in order])
+    ax.set_xticklabels(['{0}\nn={1}'.format(group, sizes[group])
+                        if group in sizes else group for group in order])
+    ax.set(title=title, yticks=yticks, ylim=ylim)
     return ax
 
 def nmf_space_transitions(nmf_space_positions, feature_id,

--- a/flotilla/visualize/generic.py
+++ b/flotilla/visualize/generic.py
@@ -1,13 +1,12 @@
-import matplotlib as mpl
 from matplotlib import pyplot as plt
 import numpy as np
 import seaborn as sns
 
 
-def violinplot(data, groupby=None, color_ordered=None, ax=None,
-               pooled_data=None,
-               order=None, violinplot_kws=None, title=None,
-               label_pooled=False, outliers=None, data_type=None):
+def violinplot(singles, groupby, color_ordered=None, ax=None,
+               pooled=None, ylabel='', bw=None,
+               order=None, title=None,
+               outliers=None, data_type=None):
     """
     Parameters
     ----------
@@ -24,159 +23,44 @@ def violinplot(data, groupby=None, color_ordered=None, ax=None,
     Raises
     ------
     """
-    data_type = 'none' if data_type is None else data_type
-    splicing = data_type == 'splicing'
-
-    violinplot_kws = {} if violinplot_kws is None else violinplot_kws
-    violinplot_kws.setdefault('alpha', 0.75)
-
     if ax is None:
         ax = plt.gca()
 
-    _violinplot_single_dataset(data, groupby=groupby, color=color_ordered,
-                               ax=ax, order=order,
-                               violinplot_kws=violinplot_kws,
-                               splicing=splicing)
-    if pooled_data is not None and groupby is not None:
-        grouped = pooled_data.groupby(groupby)
-        if order is not None:
-            for i, name in enumerate(order):
-                try:
-                    subset = pooled_data.ix[grouped.groups[name]]
-                    plot_pooled_dot(ax, subset, x_offset=i, label=label_pooled)
-                except KeyError:
-                    pass
-        else:
-            plot_pooled_dot(ax, pooled_data)
+    tidy_singles = singles.dropna().to_frame().join(groupby)
+    tidy_singles = tidy_singles.reset_index()
+    tidy_singles = tidy_singles.rename(columns={singles.name:ylabel,})
+
+    if pooled is not None:
+        tidy_pooled = pooled.dropna().to_frame().join(groupby)
+        tidy_pooled = tidy_pooled.reset_index()
+        tidy_pooled = tidy_pooled.rename(columns={pooled.name:ylabel,})
 
     if outliers is not None:
-        outlier_violinplot_kws = violinplot_kws
+        tidy_outliers = outliers.dropna().to_frame().join(groupby)
+        tidy_outliers = tidy_outliers.reset_index()
+        tidy_outliers = tidy_outliers.rename(columns={outliers.namename:ylabel,})
 
-        # make sure this is behind the non outlier data
-        outlier_violinplot_kws['zorder'] = -1
-        _violinplot_single_dataset(outliers, groupby=groupby,
-                                   color='lightgrey', ax=ax, order=order,
-                                   violinplot_kws=outlier_violinplot_kws,
-                                   splicing=splicing)
+    if outliers is not None and not outliers.dropna().empty:
+        sns.violinplot(x='phenotype', y=ylabel, data=tidy_outliers,
+                   bw=0.2, order=order, inner=None, cut=0,
+                   linewidth=1, scale='width', color='lightgrey', ax=ax)
+    if not singles.dropna().empty:
+        sns.violinplot(x='phenotype', y=ylabel, data=tidy_singles,
+                   bw=0.2, order=order, inner=None, cut=0,
+                   linewidth=1, scale='width', palette=color_ordered, ax=ax)
+    if outliers is not None and not outliers.dropna().empty:
+        sns.stripplot(x='phenotype', y=ylabel, data=tidy_outliers,
+                  jitter=True, order=order, ax=ax, color='grey')
+    if not singles.dropna().empty:
+        sns.stripplot(x='phenotype', y=ylabel, data=tidy_singles,
+                  jitter=True, order=order, ax=ax, palette=color_ordered)
+    if pooled is not None not pooled.dropna().empty:
+        sns.stripplot(x='phenotype', y=ylabel, data=tidy_pooled,
+                      jitter=True, order=order, ax=ax, color='#262626')
+    sizes = tidy_singles.groupby('phenotype').size()
 
-    if splicing:
-        ax.set_ylim(0, 1)
-        ax.set_yticks([0, 0.5, 1])
-        ax.set_ylabel('$\Psi$')
-
-    if title is not None:
-        ax.set_title(title)
-
-    if order is not None:
-        ax.set_xlim(-.5, len(order) - .5)
-
-    if groupby is not None and order is not None:
-        sizes = data.dropna().groupby(groupby).size()
-        xticks = range(len(order))
-        xticklabels = ['{}\nn={}'.format(group, sizes[group])
-                       if group in sizes else '{}\nn=0'.format(group)
-                       for group in order]
-        ax.set_xticks(xticks)
-        ax.set_xticklabels(xticklabels)
-    sns.despine()
-
-
-def _violinplot_single_dataset(data, groupby=None, order=None,
-                               violinplot_kws=None, color=None, ax=None,
-                               splicing=False):
-    """Plot a single set of violinplot.
-
-    Separated out so real data plotting and outlier plotting works the same
-    """
-    data = data.dropna()
-    if data.empty:
-        return
-
-    single_points = data.groupby(groupby).filter(lambda x: len(x) < 2)
-    data = data.groupby(groupby).filter(lambda x: len(x) > 1)
-
-    # Check that all the groups are represented, if not, add some data out of
-    # range to the missing group
-    verified_color = color
-    if groupby is not None and order is not None:
-        verified_groups = data.groupby(groupby).size().keys()
-        verified_order = [x for x in order if x in verified_groups]
-
-        positions = [i for i, x in enumerate(order) if x in verified_groups]
-
-        single_groups = single_points.groupby(groupby).size().keys()
-        single_positions = dict((x, i) for i, x in enumerate(order) if
-                                x in single_groups)
-
-        if not mpl.colors.is_color_like(color):
-            verified_color = [x for i, x in enumerate(color)
-                              if order[i] in verified_groups]
-            single_color = dict((group, c) for i, (c, group) in
-                                enumerate(zip(color, single_groups))
-                                if group in single_groups)
-        else:
-            single_color = dict((group, color) for group in single_groups if
-                                group in single_groups)
-    else:
-        verified_order = order
-        positions = None
-
-        single_positions = None
-        single_color = None
-
-    violinplot_kws = {} if violinplot_kws is None else violinplot_kws
-
-    # Add a tiny amount of random noise in case the values are all identical,
-    # Otherwise we get a LinAlg error.
-    data += np.random.uniform(0, 0.001, data.shape[0])
-
-    inner = 'points' if splicing else 'box'
-    if len(data) > 0:
-        sns.violinplot(data, groupby=groupby, bw=0.1, inner=inner,
-                       color=verified_color, linewidth=0.5,
-                       order=verified_order,
-                       ax=ax, positions=positions, **violinplot_kws)
-
-    if single_points is not None:
-        for group, y in single_points.groupby(groupby):
-            x = single_positions[group]
-            c = single_color[group]
-            ax.scatter([x], [y], color=c, s=50)
-            ax.annotate(y.index[0], (x, y), textcoords='offset points',
-                        xytext=(7, 0), fontsize=14)
-
-
-def plot_pooled_dot(ax, pooled, x_offset=0, label=False):
-    """
-    Parameters
-    ----------
-    ax : matplotlib.axes.Axes
-        Axes object to plot on
-    pooled : pandas.Series
-        Pooled data of this gene
-
-    Returns
-    -------
-
-
-    Raises
-    ------
-    """
-    pooled = pooled.dropna()
-    try:
-        xs = np.zeros(pooled.shape[0])
-    except AttributeError:
-        xs = np.zeros(1)
-    xs += x_offset
-    ax.plot(xs, pooled, 'o', color='#262626')
-
-    if label:
-        for x, y in zip(xs, pooled):
-            if np.isnan(y):
-                continue
-            ax.annotate('pooled', (x, y), textcoords='offset points',
-                        xytext=(7, 0), fontsize=14)
-
+    ax.set_xticklabels(['{0}\nn={1}'.format(group, sizes[group]) if group in sizes else group for group in order])
+    return ax
 
 def nmf_space_transitions(nmf_space_positions, feature_id,
                           phenotype_to_color, phenotype_to_marker, order,


### PR DESCRIPTION
This allows for use of `stripplot`, which will plot individual observations in addition to the violins, like this;

![image](https://cloud.githubusercontent.com/assets/806256/8534909/ea9c6b44-23f5-11e5-8887-926070bd4cfc.png)


- [ ] Is it mergable?
- [ ] Did it pass the tests?
- [ ] If it introduces new functionality in is it tested?
  Check for code coverage. To run code coverage on only the file you changed,
  for example `flotilla/compute/splicing.py`, use this command: 
  `coverage run --source flotilla --omit=test --module py.test flotilla/test/compute/test_splicing.py`
  which will show you which lines aren't covered by the tests.
- [ ] Do the new functions have descriptive 
  [numpydoc](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
  style docstrings?
- [ ] If it adds a new feature, is it documented as an IPython Notebook in 
  `examples/`, and is that notebook added to `doc/tutorial.rst`?
- [ ] If it adds a new plot, is it documented in the gallery, as a `.py` file 
  in `examples/`?
- [ ] Is it well formatted? Look at the output of `make lint`.
- [ ] Is it documented in the doc/releases/?
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?